### PR TITLE
Set isHTMLGame to a string instead of a primitive boolean. Fixes 400 error.

### DIFF
--- a/game-registration/game-registration.js
+++ b/game-registration/game-registration.js
@@ -101,6 +101,9 @@ async function registerGame(gameData) {
     payload.discord = formatUrl(gameData.discord, 'https://discord.gg/');
   }
 
+  // if this is a primitive true|false the backend throws an error complaining about expecting a string
+  payload.isHTMLGame = payload.isHTMLGame ? "true" : "false";
+
   console.log('Submitting game registration:', payload);
 
   const response = await fetch(


### PR DESCRIPTION
Prior to this change, attempt to register would result in:
```
game-registration.js:717 Registration error: Error: Registration failed: 400  - Request body malformed.
must be string
```

The error message did not specify which field was the problem, but I suspected the boolean field was the culprit. This change turns the boolean into a string and allows registrations to process successfully.